### PR TITLE
Update overview.rst to include a section on BIDS

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,8 +2,42 @@
 Installation
 ============
 
-    Please note - if you're a UNC-CH user, clpipe is already installed and accessible 
-    with the module system - please see the section below, "For UNC-CH Users"
+    Please note - if you are a UNC-CH user, clpipe is already installed and accessible 
+    with the module system. If you are not a UNC-CH user, please start at the section, 
+    "Python Environment Setup"
+
+-----------------------
+For UNC-CH Users
+-----------------------
+
+If you are a Longleaf user and a member of the rc_hng_psx group,
+clpipe has already been installed for you via the module system. 
+
+clpipe is not currently available as part of Longleaf's default module collection.
+Instead, it is provided through the HNG's module directory, which you must
+setup manually.
+
+First, make the HNG modules available:
+
+.. code-block:: console
+
+    module use /proj/hng/software/modules
+
+Now save this module source to your default collection:
+
+.. code-block:: console
+
+    module save
+
+You can then use the following to access the latest version of clpipe at any time:
+
+.. code-block:: console
+
+    module add clpipe
+
+You also already have access to the latest singularity images for both fmriprep 
+and the bids validator at ``/proj/hng/singularity_imgs``, 
+so there is no need to construct your own, unless you want a older version.
 
 -----------------------
 Python Environment Setup

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,13 +16,16 @@ Getting started on Longleaf
 clpipe uses `Longleaf <https://help.rc.unc.edu/longleaf-cluster>`_, a Linux-based HPC
 available to researchers across the campus free of charge. All UNC-CH clpipe users will
 need a Longleaf account. To request a Longleaf account, follow these `instructions <https://help.rc.unc.edu/request-a-cluster-account/>`_.
-Users can access the Longleaf cluster by using either the web-portal, `OnDemand <https://help.rc.unc.edu/ondemand>
+Users can access the Longleaf cluster by using either the web-portal, `OnDemand <https://help.rc.unc.edu/ondemand>`_, 
+or on the terminal of your local computer. For more instructions on how to use Longleaf see the UNC ITS Research Computing's
+Longleaf `guide <https://drive.google.com/file/d/1YCV5jONUYGZRxSOnaXGzA4-oPP61W2Sy/view`_.
 
 Accessing the clpipe module
 -----------------------------
 
 If you are a Longleaf user and a member of the rc_hng_psx group,
 clpipe has already been installed for you via the module system. 
+To check if you are a member of the rc_hng_psx group
 
 clpipe is not currently available as part of Longleaf's default module collection.
 Instead, it is provided through the UNC Human Neuroimaging Group's module directory, 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -18,20 +18,18 @@ available to researchers across the campus free of charge. All UNC-CH clpipe use
 need a Longleaf account. To request a Longleaf account, follow these `instructions <https://help.rc.unc.edu/request-a-cluster-account/>`_.
 Users can access the Longleaf cluster by using either the web-portal, `OnDemand <https://help.rc.unc.edu/ondemand>`_, 
 or on the terminal of your local computer. For more instructions on how to use Longleaf see the UNC ITS Research Computing's
-Longleaf `guide <https://drive.google.com/file/d/1YCV5jONUYGZRxSOnaXGzA4-oPP61W2Sy/view`_.
+Longleaf `guide <https://drive.google.com/file/d/1YCV5jONUYGZRxSOnaXGzA4-oPP61W2Sy/view>`_.
 
 Accessing the clpipe module
 -----------------------------
 
-If you are a Longleaf user and a member of the rc_hng_psx group,
-clpipe has already been installed for you via the module system. 
-To check if you are a member of the rc_hng_psx group
+Longleaf modules are a series of software installations and applications that allow users to access programming tools 
+or alternate versions of standard packages. If you are a Longleaf user and a member of the rc_hng_psx group, 
+clpipe has already been installed for you via the module system. To check if you are a member of the rc_hng_psx group
 
 clpipe is not currently available as part of Longleaf's default module collection.
 Instead, it is provided through the UNC Human Neuroimaging Group's module directory, 
 which you must setup manually.
-
-First, make sure you are a member of the rc_hng_psx group:
 
 
 Second, make the HNG modules available:
@@ -51,6 +49,7 @@ You can then use the following to access the latest version of clpipe at any tim
 .. code-block:: console
 
     module add clpipe
+
 Additional module commands
 #################
 
@@ -79,11 +78,6 @@ View all options for a give module:
 .. code-block:: console
 
     module help <modulename>
-
-
-
-
-
 
 
 Singularity images

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,14 +10,28 @@ Installation
 For UNC-CH Users
 -----------------------
 
+Getting started on Longleaf
+---------------------------
+
+clpipe uses `Longleaf <https://help.rc.unc.edu/longleaf-cluster>`_, a Linux-based HPC
+available to researchers across the campus free of charge. All UNC-CH clpipe users will
+need a Longleaf account. To request a Longleaf account, follow these `instructions <https://help.rc.unc.edu/request-a-cluster-account/>`_.
+Users can access the Longleaf cluster by using either the web-portal, `OnDemand <https://help.rc.unc.edu/ondemand>
+
+Accessing the clpipe module
+-----------------------------
+
 If you are a Longleaf user and a member of the rc_hng_psx group,
 clpipe has already been installed for you via the module system. 
 
 clpipe is not currently available as part of Longleaf's default module collection.
-Instead, it is provided through the HNG's module directory, which you must
-setup manually.
+Instead, it is provided through the UNC Human Neuroimaging Group's module directory, 
+which you must setup manually.
 
-First, make the HNG modules available:
+First, make sure you are a member of the rc_hng_psx group:
+
+
+Second, make the HNG modules available:
 
 .. code-block:: console
 
@@ -34,9 +48,46 @@ You can then use the following to access the latest version of clpipe at any tim
 .. code-block:: console
 
     module add clpipe
+Additional module commands
+#################
 
-You also already have access to the latest singularity images for both fmriprep 
-and the bids validator at ``/proj/hng/singularity_imgs``, 
+Other basic module commands are provide below.
+
+List all modules on Lonfleaf: 
+
+.. code-block:: console
+
+    module avail
+
+View all your currently loaded modules: 
+
+.. code-block:: console
+
+    module list <modulename>
+
+Remove or unload a loaded module: 
+
+.. code-block:: console
+
+    module rm <modulename>
+
+View all options for a give module: 
+
+.. code-block:: console
+
+    module help <modulename>
+
+
+
+
+
+
+
+Singularity images
+#################
+
+Members of the rc_hng_psx group already have access to the latest singularity images for both `fMRIPrep` 
+and bids validators at ``/proj/hng/singularity_imgs``, 
 so there is no need to construct your own, unless you want a older version.
 
 -----------------------
@@ -98,39 +149,6 @@ by the clpipe module):
 - FSL >= v6.0.0
 - AFNI >= v20.0.00
 - R >= v4.0.0
-
------------------------
-For UNC-CH Users
------------------------
-
-If you are a Longleaf user and a member of the rc_hng_psx group,
-clpipe has already been installed for you via the module system. 
-
-clpipe is not currently available as part of Longleaf's default module collection.
-Instead, it is provided through the HNG's module directory, which you must
-setup manually.
-
-First, make the HNG modules available:
-
-.. code-block:: console
-
-    module use /proj/hng/software/modules
-
-Now save this module source to your default collection:
-
-.. code-block:: console
-
-    module save
-
-You can then use the following to access the latest version of clpipe at any time:
-
-.. code-block:: console
-
-    module add clpipe
-
-You also already have access to the latest singularity images for both fmriprep 
-and the bids validator at ``/proj/hng/singularity_imgs``, 
-so there is no need to construct your own, unless you want a older version.
 
 ---------------
 Batch Languages

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,11 +25,14 @@ Accessing the clpipe module
 
 Longleaf modules are a series of software installations and applications that allow users to access programming tools 
 or alternate versions of standard packages. If you are a Longleaf user and a member of the rc_hng_psx group, 
-clpipe has already been installed for you via the module system. To check if you are a member of the rc_hng_psx group
+clpipe has already been installed for you via the module system.
 
-clpipe is not currently available as part of Longleaf's default module collection.
-Instead, it is provided through the UNC Human Neuroimaging Group's module directory, 
+clpipe is not currently available as part of Longleaf's default module collection. 
+Instead, it is provided through the UNC Human Neuroimaging Group (HNG)'s module directory, 
 which you must setup manually.
+
+To check if you are a member of the UNC HNG group... rc_hng_psx group
+
 
 
 Second, make the HNG modules available:
@@ -49,6 +52,12 @@ You can then use the following to access the latest version of clpipe at any tim
 .. code-block:: console
 
     module add clpipe
+
+To view what version of clpipe is currently loaded:
+
+.. code-block:: console
+
+    clpipe -v
 
 Additional module commands
 #################

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -6,10 +6,10 @@ BIDS Format
 *****************
 
 Brain Imaging Data Structure (BIDS) is a framework for organizing data that standardizes file 
-organization and dataset description between different projects. clpipe uses `fMRIprep <https://fmriprep.readthedocs.io/en/stable/>` 
-and other other applications that require input data to be in BIDS format. The first steps in the clpipe workflow are to convert 
-the directories and configuration files for a given neuroimaging project to BIDS format. For more information on BIDS,
-you can browse the `BIDS workbook <https://bids-standard.github.io/bids-starter-kit/>` 
+organization and dataset description between different projects. clpipe uses `fMRIprep <https://fmriprep.readthedocs.io/en/stable/>`_ 
+and other other applications that require input data to be in BIDS format. The `project_setup`, `convert2bids`, and `bids_validate`
+commands in the clpipe workflow are convience functions to standardize the directories and files for a given neuroimaging project 
+to BIDS format. For more information on BIDS, you can browse the `BIDS workbook <https://bids-standard.github.io/bids-starter-kit/>`_. 
 
 *****************
 The Command Line Interface

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,69 +1,15 @@
 ===================
 Overview
 ===================
-
 *****************
-Configuration Files
+BIDS Format
 *****************
 
-clpipe is driven by configuration files, and most commands in clpipe require a configuration file path
-via their '-config_file' option. These configuration files are JSONs that contain 
-all aspects of the preprocessing and postprocessing streams that 
-you want applied to your dataset. 
-clpipe provides you with a default configuration file after using the `project_setup`
-command. To create addition configuration files for your dataset, use the following command:
-
-.. click:: clpipe.cli:get_config_file
-	:prog: clpipe config get
-
-This command will create a default configuration file with whatever name you specified. 
-The top of the default configuration file looks like this:
-
-.. code-block:: json
-
-    {
-        "project_title": "test_project",
-        "contributors": "SET CONTRIBUTORS",
-        "project_directory": "/nas/longleaf/home/user/clpipe",
-        "email_address": "SET EMAIL ADDRESS",
-        "source": {
-            "source_url": "fw://",
-            "dropoff_directory": "",
-            "temp_directory": "",
-            "commandline_opts": "-y",
-            "time_usage": "1:0:0",
-            "mem_usage": "10G",
-            "core_usage": "2"
-        },
-        "convert2bids": {
-            "dicom_directory": "/nas/longleaf/home/user/clpipe/data_DICOMs",
-            "bids_directory": "/nas/longleaf/home/user/clpipe/data_BIDS",
-            "conversion_config": "/nas/longleaf/home/user/clpipe/conversion_config.json",
-            "dicom_format_string": "",
-            "time_usage": "1:0:0",
-            "mem_usage": "5000",
-            "core_usage": "2",
-            "log_directory": "/nas/longleaf/home/user/clpipe/logs/DCM2BIDS_logs"
-        },
-        ...
-    }
-
-The configuration file consists of some project-level metadata, such as "ProjectTitle",
-and a set of Option blocks that contain their own sub-settings. Each Option block
-corresponds to a clpipe command, and controls the input parameters for that step.
-For example, "DICOMtoBIDSOptions" corresponds to the convert2bids command. You can
-find explanations for each specific Option block on the documenation page for its
-corresponding command.
-
-All of these fields have what the designers of clpipe consider to 
-be reasonable defaults for processing. 
-Additionally, users at UNC-CH on the Longleaf cluster with access to the 
-HNG group should be able to use the default options with no change. 
-Other users will have to modify several fields. 
-
-Described here are the project-level meta fields of the configuration file:
-
-.. autoclass:: clpipe.config.options.ProjectOptions
+Brain Imaging Data Structure (BIDS) is a framework for organizing data that standardizes file 
+organization and dataset description between different projects. clpipe uses `fMRIprep <https://fmriprep.readthedocs.io/en/stable/>` 
+and other other applications that require input data to be in BIDS format. The first steps in the clpipe workflow are to convert 
+the directories and configuration files for a given neuroimaging project to BIDS format. For more information on BIDS,
+you can browse the `BIDS workbook <https://bids-standard.github.io/bids-starter-kit/>` 
 
 *****************
 The Command Line Interface
@@ -166,3 +112,66 @@ Job Submission
 *****************
 
 .. autoclass:: clpipe.config.options.ParallelManagerConfig
+
+*****************
+Configuration Files
+*****************
+
+clpipe is driven by configuration files, and most commands in clpipe require a configuration file path
+via their '-config_file' option. These configuration files are JSONs that contain 
+all aspects of the preprocessing and postprocessing streams that 
+you want applied to your dataset. 
+clpipe provides you with a default configuration file after using the `project_setup`
+command. To create addition configuration files for your dataset, use the following command:
+
+.. click:: clpipe.cli:get_config_file
+	:prog: clpipe config get
+
+This command will create a default configuration file with whatever name you specified. 
+The top of the default configuration file looks like this:
+
+.. code-block:: json
+
+    {
+        "project_title": "test_project",
+        "contributors": "SET CONTRIBUTORS",
+        "project_directory": "/nas/longleaf/home/user/clpipe",
+        "email_address": "SET EMAIL ADDRESS",
+        "source": {
+            "source_url": "fw://",
+            "dropoff_directory": "",
+            "temp_directory": "",
+            "commandline_opts": "-y",
+            "time_usage": "1:0:0",
+            "mem_usage": "10G",
+            "core_usage": "2"
+        },
+        "convert2bids": {
+            "dicom_directory": "/nas/longleaf/home/user/clpipe/data_DICOMs",
+            "bids_directory": "/nas/longleaf/home/user/clpipe/data_BIDS",
+            "conversion_config": "/nas/longleaf/home/user/clpipe/conversion_config.json",
+            "dicom_format_string": "",
+            "time_usage": "1:0:0",
+            "mem_usage": "5000",
+            "core_usage": "2",
+            "log_directory": "/nas/longleaf/home/user/clpipe/logs/DCM2BIDS_logs"
+        },
+        ...
+    }
+
+The configuration file consists of some project-level metadata, such as "ProjectTitle",
+and a set of Option blocks that contain their own sub-settings. Each Option block
+corresponds to a clpipe command, and controls the input parameters for that step.
+For example, "DICOMtoBIDSOptions" corresponds to the convert2bids command. You can
+find explanations for each specific Option block on the documenation page for its
+corresponding command.
+
+All of these fields have what the designers of clpipe consider to 
+be reasonable defaults for processing. 
+Additionally, users at UNC-CH on the Longleaf cluster with access to the 
+HNG group should be able to use the default options with no change. 
+Other users will have to modify several fields. 
+
+Described here are the project-level meta fields of the configuration file:
+
+.. autoclass:: clpipe.config.options.ProjectOptions

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -6,7 +6,7 @@ BIDS Format
 *****************
 
 Brain Imaging Data Structure (BIDS) is a framework for organizing data that standardizes file 
-organization and dataset description between different projects. clpipe uses `fMRIprep <https://fmriprep.readthedocs.io/en/stable/>`_ 
+organization and dataset description between different projects. clpipe uses `fMRIPrep <https://fmriprep.readthedocs.io/en/stable/>`_ 
 and other other applications that require input data to be in BIDS format. The `project_setup`, `convert2bids`, and `bids_validate`
 commands in the clpipe workflow are convience functions to standardize the directories and files for a given neuroimaging project 
 to BIDS format. For more information on BIDS, you can browse the `BIDS workbook <https://bids-standard.github.io/bids-starter-kit/>`_. 


### PR DESCRIPTION
Also rearranged the order of sections. For context, some faculty at UNC have asked a group of post-docs, graduate students, and research staff to help update the clpipe readthedocs.